### PR TITLE
Don't set SEND_TO_MASTER-Flag for responses

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -357,7 +357,7 @@ void sendResponse(uint8_t *msg, uint8_t type) {
 		#endif
 	}
 
-	uint8_t responseMsg[11] = { 10, msg[1], 0x80, 0x02, hmID[0], hmID[1], hmID[2], msg[4], msg[5], msg[6], type };
+	uint8_t responseMsg[11] = { 10, msg[1], 0x00, 0x02, hmID[0], hmID[1], hmID[2], msg[4], msg[5], msg[6], type };
 	hmEncodeAndSendData(responseMsg);
 }
 


### PR DESCRIPTION
Official devices don't set this flag and certain (unofficial) Gateways like Homegear expect this to be absent.